### PR TITLE
Fixed build to exclude react & react-dom

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -19,6 +19,8 @@ gulp.task('build', () =>
     extensions: ['jsx'],
     standalone: 'ElectronWebView',
   }).transform(babelify)
+    .external('react')
+    .external('react-dom')
     .bundle()
     .on('error', gutil.log)
     .pipe(source(config.outputFile))


### PR DESCRIPTION
Since react and react-dom are peer dependencies, they should not be built into the distributable version of this package.  This fixes #7.