### PR TITLE
avoid accumulating copies of event handlers when reattaching

### DIFF
--- a/src/ElectronWebView.jsx
+++ b/src/ElectronWebView.jsx
@@ -24,14 +24,16 @@ export default class ElectronWebView extends Component {
 
     this.ready = false;
     this.view.addEventListener('did-attach', (...attachArgs) => {
-      this.ready = true;
-      events.forEach((event) => {
-        this.view.addEventListener(event, (...eventArgs) => {
-          const propName = camelCase(`on-${event}`);
-          // console.log('Firing event: ', propName, ' has listener: ', !!this.props[propName]);
-          if (this.props[propName]) this.props[propName](...eventArgs);
+      if(!this.ready) {
+        this.ready = true;
+        events.forEach((event) => {
+          this.view.addEventListener(event, (...eventArgs) => {
+            const propName = camelCase(`on-${event}`);
+            // console.log('Firing event: ', propName, ' has listener: ', !!this.props[propName]);
+            if (this.props[propName]) this.props[propName](...eventArgs);
+          });
         });
-      });
+      }
       if (this.props.onDidAttach) this.props.onDidAttach(...attachArgs);
     });
 


### PR DESCRIPTION
I ran into the same issue as #3 (did-attach firing again after setting a surrounding container display:none, then display: block). The simplest fix seemed to be to just not add the events again if we did it once before. All this commit does is add the if statement to accomplish that.